### PR TITLE
P6: Preview beautification & print/PDF support

### DIFF
--- a/src/app/preview/page.tsx
+++ b/src/app/preview/page.tsx
@@ -1,9 +1,24 @@
 "use client";
 
+import { useCallback, useRef } from "react";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
+import { useReactToPrint } from "react-to-print";
+
+import PrimaryButton from "@/components/ui/PrimaryButton";
 import { useResumeStore } from "@/store/resume";
 
+export const displayValue = (value?: string | null) => {
+  if (!value) {
+    return "未入力";
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : "未入力";
+};
+
 export default function PreviewPage() {
+  const router = useRouter();
   const { profile, education, employment, licenses, prText, cv, cvResult } = useResumeStore((state) => ({
     profile: state.profile,
     education: state.education,
@@ -13,227 +28,310 @@ export default function PreviewPage() {
     cv: state.cv,
     cvResult: state.cvResult,
   }));
+  const printContentRef = useRef<HTMLDivElement>(null);
+
+  const triggerPrint = useReactToPrint({
+    content: () => printContentRef.current,
+    documentTitle: profile.name ? `${profile.name}-resume` : "resume-preview",
+  });
+
+  const handlePrint = useCallback(() => {
+    triggerPrint?.();
+  }, [triggerPrint]);
+
+  const handlePdfDownload = useCallback(() => {
+    triggerPrint?.();
+  }, [triggerPrint]);
+
+  const handleBack = useCallback(() => {
+    router.push("/");
+  }, [router]);
 
   const hasResumeContent =
-    profile.name || education.length > 0 || employment.length > 0 || licenses.length > 0 || prText;
+    displayValue(profile.name) !== "未入力" ||
+    displayValue(profile.address) !== "未入力" ||
+    displayValue(profile.phone) !== "未入力" ||
+    displayValue(profile.email) !== "未入力" ||
+    displayValue(profile.birth) !== "未入力" ||
+    education.length > 0 ||
+    employment.length > 0 ||
+    licenses.length > 0 ||
+    (prText?.trim()?.length ?? 0) > 0;
+
+  const hasCvContent =
+    displayValue(cv.jobProfile.name) !== "未入力" ||
+    displayValue(cv.jobProfile.title) !== "未入力" ||
+    displayValue(cv.jobProfile.summary) !== "未入力" ||
+    cv.experiences.length > 0 ||
+    Boolean(cvResult);
 
   return (
-    <div className="flex w-full justify-center overflow-x-auto py-4">
-      <div className="w-full max-w-[794px] space-y-6 rounded-xl bg-white p-8 shadow-lg">
-        <header className="border-b border-slate-200 pb-4">
-          <h1 className="text-2xl font-semibold text-slate-900">プレビュー</h1>
-          <p className="mt-1 text-sm text-slate-600">入力した内容を印刷レイアウトに近い形で確認できます。</p>
-        </header>
+    <div className="min-h-screen bg-slate-100 py-8 print:bg-white print:py-0">
+      <div className="mx-auto w-full max-w-[820px] px-4 print:w-auto print:max-w-none print:px-0">
+        <div className="mb-4 flex justify-end gap-3 print:hidden">
+          <PrimaryButton onClick={handlePrint} aria-label="印刷プレビューを開く">
+            印刷
+          </PrimaryButton>
+          <PrimaryButton onClick={handlePdfDownload} aria-label="PDFとして保存する">
+            PDFダウンロード
+          </PrimaryButton>
+          <PrimaryButton onClick={handleBack} aria-label="入力画面に戻る">
+            戻る
+          </PrimaryButton>
+        </div>
 
-        <section className="space-y-4">
-          <h2 className="text-xl font-semibold text-slate-900">履歴書</h2>
-          {hasResumeContent ? (
-            <div className="space-y-6">
-              <div className="flex flex-col gap-4 border border-slate-200 p-4 sm:flex-row">
-                <div className="flex-1 space-y-2">
-                  <div>
-                    <p className="text-xs uppercase tracking-wide text-slate-500">氏名</p>
-                    <p className="text-lg font-semibold text-slate-900">{profile.name || "未入力"}</p>
-                    {profile.nameKana ? <p className="text-sm text-slate-600">{profile.nameKana}</p> : null}
-                  </div>
-                  <div className="grid gap-2 text-sm text-slate-700 sm:grid-cols-2">
-                    <div>
-                      <p className="text-xs uppercase tracking-wide text-slate-500">生年月日</p>
-                      <p>{profile.birth || "-"}</p>
-                    </div>
-                    <div>
-                      <p className="text-xs uppercase tracking-wide text-slate-500">電話番号</p>
-                      <p>{profile.phone || "-"}</p>
-                    </div>
-                    <div>
-                      <p className="text-xs uppercase tracking-wide text-slate-500">メール</p>
-                      <p>{profile.email || "-"}</p>
-                    </div>
-                    <div className="sm:col-span-2">
-                      <p className="text-xs uppercase tracking-wide text-slate-500">住所</p>
-                      <p>{profile.address || "-"}</p>
-                    </div>
-                  </div>
-                </div>
-                <div className="flex w-full max-w-[180px] items-center justify-center">
-                  <div className="relative aspect-[4/3] w-full overflow-hidden rounded-md border border-slate-200 bg-slate-100">
-                    {profile.avatarUrl ? (
-                      <Image
-                        src={profile.avatarUrl}
-                        alt="プロフィール画像"
-                        fill
-                        className="object-cover"
-                        sizes="180px"
-                        unoptimized
-                      />
-                    ) : (
-                      <p className="flex h-full items-center justify-center text-xs text-slate-500">写真なし</p>
-                    )}
-                  </div>
-                </div>
-              </div>
+        <div
+          ref={printContentRef}
+          className="print-container mx-auto w-[794px] space-y-8 bg-white p-10 text-black shadow print:w-full print:bg-white print:p-0 print:text-black"
+        >
+          <header className="border-b pb-4">
+            <h1 className="text-2xl font-semibold text-slate-900">履歴書・職務経歴書プレビュー</h1>
+            <p className="mt-1 text-sm text-slate-600">入力した情報をA4レイアウトで確認できます。</p>
+          </header>
 
-              <div className="space-y-3">
-                <h3 className="text-base font-semibold text-slate-900">学歴</h3>
-                {education.length > 0 ? (
-                  <ul className="space-y-2 text-sm text-slate-700">
-                    {education.map((entry, index) => (
-                      <li key={`education-${index}`} className="flex flex-col sm:flex-row sm:items-center sm:justify-between">
-                        <span className="font-medium text-slate-800">{entry.school}</span>
-                        <span className="text-slate-600">
-                          {entry.start} 〜 {entry.end} ／ {entry.status}
-                          {entry.degree ? `（${entry.degree}）` : ""}
-                        </span>
-                      </li>
-                    ))}
-                  </ul>
-                ) : (
-                  <p className="text-sm text-slate-500">登録された学歴はありません。</p>
-                )}
-              </div>
-
-              <div className="space-y-3">
-                <h3 className="text-base font-semibold text-slate-900">職歴</h3>
-                {employment.length > 0 ? (
-                  <ul className="space-y-2 text-sm text-slate-700">
-                    {employment.map((entry, index) => (
-                      <li key={`employment-${index}`} className="flex flex-col sm:flex-row sm:items-center sm:justify-between">
-                        <span className="font-medium text-slate-800">{entry.company}</span>
-                        <span className="text-slate-600">
-                          {entry.start} 〜 {entry.end} ／ {entry.role} ／ {entry.status}
-                        </span>
-                      </li>
-                    ))}
-                  </ul>
-                ) : (
-                  <p className="text-sm text-slate-500">登録された職歴はありません。</p>
-                )}
-              </div>
-
-              <div className="space-y-3">
-                <h3 className="text-base font-semibold text-slate-900">資格・免許</h3>
-                {licenses.length > 0 ? (
-                  <ul className="space-y-1 text-sm text-slate-700">
-                    {licenses.map((entry, index) => (
-                      <li key={`license-${index}`}>
-                        {entry.name}（取得：{entry.obtainedOn}）
-                      </li>
-                    ))}
-                  </ul>
-                ) : (
-                  <p className="text-sm text-slate-500">登録された資格はありません。</p>
-                )}
-              </div>
-
-              <div className="space-y-2">
-                <h3 className="text-base font-semibold text-slate-900">自己PR</h3>
-                <p className="min-h-[80px] whitespace-pre-line rounded-md border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
-                  {prText || "自己PR文はまだ生成されていません。"}
-                </p>
-              </div>
+          <section>
+            <div className="mb-6 border-b pb-4">
+              <h2 className="text-xl font-semibold text-slate-900">履歴書</h2>
             </div>
-          ) : (
-            <p className="text-sm text-slate-500">履歴書情報がまだ入力されていません。</p>
-          )}
-        </section>
-
-        <section className="space-y-4">
-          <h2 className="text-xl font-semibold text-slate-900">職務経歴書</h2>
-          {cv.experiences.length > 0 || cv.jobProfile.title || cvResult ? (
-            <div className="space-y-6">
-              <div className="rounded-lg border border-slate-200 p-4">
-                <h3 className="text-base font-semibold text-slate-900">プロフィール</h3>
-                <dl className="mt-3 grid gap-2 text-sm text-slate-700 sm:grid-cols-2">
-                  <div>
-                    <dt className="text-xs uppercase tracking-wide text-slate-500">氏名</dt>
-                    <dd>{cv.jobProfile.name || profile.name || "-"}</dd>
-                  </div>
-                  <div>
-                    <dt className="text-xs uppercase tracking-wide text-slate-500">タイトル</dt>
-                    <dd>{cv.jobProfile.title || "-"}</dd>
-                  </div>
-                  <div className="sm:col-span-2">
-                    <dt className="text-xs uppercase tracking-wide text-slate-500">要約</dt>
-                    <dd>{cv.jobProfile.summary || "-"}</dd>
-                  </div>
-                </dl>
-              </div>
-
-              <div className="space-y-3">
-                <h3 className="text-base font-semibold text-slate-900">経験</h3>
-                {cv.experiences.length > 0 ? (
+            {hasResumeContent ? (
+              <div className="space-y-8 text-sm text-slate-800">
+                <div className="grid gap-6 md:grid-cols-[1fr_auto]">
                   <div className="space-y-4">
-                    {cv.experiences.map((experience, index) => (
-                      <div key={`cv-experience-${index}`} className="rounded-lg border border-slate-200 p-4">
-                        <h4 className="text-sm font-semibold text-slate-900">{experience.company}</h4>
-                        <p className="text-sm text-slate-600">{experience.period} ／ {experience.role}</p>
-                        {experience.achievements.length > 0 ? (
-                          <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-slate-700">
-                            {experience.achievements.map((achievement, achievementIndex) => (
-                              <li key={`achievement-${index}-${achievementIndex}`}>{achievement}</li>
-                            ))}
-                          </ul>
-                        ) : null}
+                    <div>
+                      <p className="text-lg font-semibold text-slate-900">{displayValue(profile.name)}</p>
+                      {profile.nameKana ? (
+                        <p className="text-sm text-slate-600">{profile.nameKana}</p>
+                      ) : null}
+                    </div>
+                    <dl className="grid gap-x-6 gap-y-3 sm:grid-cols-2">
+                      <div>
+                        <dt className="text-xs uppercase tracking-wide text-slate-500">生年月日</dt>
+                        <dd className="text-sm">{displayValue(profile.birth)}</dd>
                       </div>
-                    ))}
+                      <div>
+                        <dt className="text-xs uppercase tracking-wide text-slate-500">電話番号</dt>
+                        <dd className="text-sm">{displayValue(profile.phone)}</dd>
+                      </div>
+                      <div className="sm:col-span-2">
+                        <dt className="text-xs uppercase tracking-wide text-slate-500">メール</dt>
+                        <dd className="text-sm">{displayValue(profile.email)}</dd>
+                      </div>
+                      <div className="sm:col-span-2">
+                        <dt className="text-xs uppercase tracking-wide text-slate-500">住所</dt>
+                        <dd className="text-sm">{displayValue(profile.address)}</dd>
+                      </div>
+                    </dl>
                   </div>
-                ) : (
-                  <p className="text-sm text-slate-500">職務経歴の入力はまだありません。</p>
-                )}
-              </div>
-
-              {cvResult ? (
-                <div className="space-y-4 rounded-lg border border-slate-200 p-4">
-                  <div>
-                    <h3 className="text-base font-semibold text-slate-900">AI生成サマリー</h3>
-                    <p className="mt-2 whitespace-pre-line text-sm text-slate-700">{cvResult.summary}</p>
-                  </div>
-                  <div>
-                    <h3 className="text-base font-semibold text-slate-900">AIが整理した経験</h3>
-                    <div className="mt-2 space-y-3">
-                      {cvResult.companies.map((company) => (
-                        <div key={`${company.name}-${company.term}`} className="rounded-md border border-slate-200 p-3">
-                          <h4 className="text-sm font-semibold text-slate-900">
-                            {company.name}（{company.term}）
-                          </h4>
-                          <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-slate-700">
-                            {company.roles.map((role) => (
-                              <li key={`cv-result-role-${company.name}-${role}`}>{role}</li>
-                            ))}
-                            {company.tasks.map((task) => (
-                              <li key={`cv-result-task-${company.name}-${task}`}>{task}</li>
-                            ))}
-                            {company.achievements.map((achievement) => (
-                              <li key={`cv-result-achievement-${company.name}-${achievement}`}>{achievement}</li>
-                            ))}
-                          </ul>
-                        </div>
-                      ))}
+                  <div className="flex w-full justify-end">
+                    <div className="relative aspect-[4/3] w-full max-w-[160px] overflow-hidden rounded-md border border-slate-200 bg-slate-200">
+                      {profile.avatarUrl ? (
+                        <Image
+                          src={profile.avatarUrl}
+                          alt="プロフィール画像"
+                          fill
+                          className="object-cover"
+                          sizes="160px"
+                          unoptimized
+                        />
+                      ) : (
+                        <div className="flex h-full w-full items-center justify-center text-xs text-slate-500">No Image</div>
+                      )}
                     </div>
                   </div>
-                  <div>
-                    <h3 className="text-base font-semibold text-slate-900">AI提案：活かせる経験</h3>
-                    <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-slate-700">
-                      {cvResult.leverage.map((item) => (
-                        <li key={`cv-result-leverage-${item.title}`}>
-                          <span className="font-semibold">{item.title}：</span>
-                          <span className="ml-1">{item.example}</span>
+                </div>
+
+                <div className="space-y-4">
+                  <h3 className="text-lg font-semibold text-slate-900">学歴</h3>
+                  {education.length > 0 ? (
+                    <ul className="space-y-3">
+                      {education.map((entry, index) => (
+                        <li key={`education-${index}`} className="flex flex-col gap-1 md:flex-row md:items-center md:justify-between">
+                          <span className="font-medium text-slate-900">{displayValue(entry.school)}</span>
+                          <span className="text-slate-600">
+                            {displayValue(entry.start)} 〜 {displayValue(entry.end)} ／ {displayValue(entry.status)}
+                            {entry.degree ? `（${entry.degree}）` : ""}
+                          </span>
                         </li>
                       ))}
                     </ul>
-                  </div>
-                  <div>
-                    <h3 className="text-base font-semibold text-slate-900">AI生成 自己PR</h3>
-                    <p className="mt-2 whitespace-pre-line text-sm text-slate-700">{cvResult.selfPR}</p>
-                  </div>
+                  ) : (
+                    <p className="text-slate-500">未入力</p>
+                  )}
                 </div>
-              ) : null}
+
+                <div className="space-y-4">
+                  <h3 className="text-lg font-semibold text-slate-900">職歴</h3>
+                  {employment.length > 0 ? (
+                    <ul className="space-y-3">
+                      {employment.map((entry, index) => (
+                        <li key={`employment-${index}`} className="flex flex-col gap-1 md:flex-row md:items-center md:justify-between">
+                          <span className="font-medium text-slate-900">{displayValue(entry.company)}</span>
+                          <span className="text-slate-600">
+                            {displayValue(entry.start)} 〜 {displayValue(entry.end)} ／ {displayValue(entry.role)} ／ {displayValue(entry.status)}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="text-slate-500">未入力</p>
+                  )}
+                </div>
+
+                <div className="space-y-4">
+                  <h3 className="text-lg font-semibold text-slate-900">資格・免許</h3>
+                  {licenses.length > 0 ? (
+                    <ul className="space-y-2">
+                      {licenses.map((entry, index) => (
+                        <li key={`license-${index}`} className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                          <span className="font-medium text-slate-900">{displayValue(entry.name)}</span>
+                          <span className="text-slate-600">取得：{displayValue(entry.obtainedOn)}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="text-slate-500">未入力</p>
+                  )}
+                </div>
+
+                <div className="space-y-3">
+                  <h3 className="text-lg font-semibold text-slate-900">自己PR</h3>
+                  <p className="min-h-[120px] whitespace-pre-line rounded-md border border-slate-200 bg-slate-50 p-4 text-sm leading-relaxed text-slate-700">
+                    {prText?.trim() ? prText : "未入力"}
+                  </p>
+                </div>
+              </div>
+            ) : (
+              <p className="text-sm text-slate-500">履歴書情報がまだ入力されていません。</p>
+            )}
+          </section>
+
+          <section>
+            <div className="mb-6 border-b pb-4">
+              <h2 className="text-xl font-semibold text-slate-900">職務経歴書</h2>
             </div>
-          ) : (
-            <p className="text-sm text-slate-500">職務経歴書の情報がまだ入力されていません。</p>
-          )}
-        </section>
+            {hasCvContent ? (
+              <div className="space-y-8 text-sm text-slate-800">
+                <div className="space-y-3">
+                  <h3 className="text-lg font-semibold text-slate-900">職務プロフィール</h3>
+                  <dl className="grid gap-x-6 gap-y-3 sm:grid-cols-2">
+                    <div>
+                      <dt className="text-xs uppercase tracking-wide text-slate-500">氏名</dt>
+                      <dd>{displayValue(cv.jobProfile.name) !== "未入力" ? cv.jobProfile.name : displayValue(profile.name)}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs uppercase tracking-wide text-slate-500">タイトル</dt>
+                      <dd>{displayValue(cv.jobProfile.title)}</dd>
+                    </div>
+                    <div className="sm:col-span-2">
+                      <dt className="text-xs uppercase tracking-wide text-slate-500">要約</dt>
+                      <dd>{displayValue(cv.jobProfile.summary)}</dd>
+                    </div>
+                  </dl>
+                </div>
+
+                <div className="space-y-4">
+                  <h3 className="text-lg font-semibold text-slate-900">経験</h3>
+                  {cv.experiences.length > 0 ? (
+                    <div className="space-y-6">
+                      {cv.experiences.map((experience, index) => (
+                        <div key={`cv-experience-${index}`} className="space-y-3">
+                          <div className="border-b pb-2">
+                            <h4 className="text-base font-semibold text-slate-900">{displayValue(experience.company)}</h4>
+                            <p className="text-sm text-slate-600">
+                              {displayValue(experience.period)} ／ {displayValue(experience.role)}
+                            </p>
+                          </div>
+                          {experience.achievements.length > 0 ? (
+                            <ul className="list-disc space-y-2 pl-5">
+                              {experience.achievements.map((achievement, achievementIndex) => (
+                                <li key={`achievement-${index}-${achievementIndex}`} className="text-slate-700">
+                                  {displayValue(achievement)}
+                                </li>
+                              ))}
+                            </ul>
+                          ) : (
+                            <p className="text-slate-500">未入力</p>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-slate-500">未入力</p>
+                  )}
+                </div>
+
+                {cvResult ? (
+                  <div className="space-y-6 rounded-md border border-slate-200 p-6">
+                    <div className="space-y-3">
+                      <h3 className="text-lg font-semibold text-slate-900">AI生成サマリー</h3>
+                      <p className="whitespace-pre-line text-sm leading-relaxed text-slate-700">{displayValue(cvResult.summary)}</p>
+                    </div>
+                    <div className="space-y-3">
+                      <h3 className="text-lg font-semibold text-slate-900">AIが整理した経験</h3>
+                      <div className="space-y-4">
+                        {cvResult.companies.map((company) => (
+                          <div key={`${company.name}-${company.term}`} className="rounded border border-slate-200 p-4">
+                            <h4 className="text-base font-semibold text-slate-900">
+                              {displayValue(company.name)}（{displayValue(company.term)}）
+                            </h4>
+                            <ul className="mt-2 list-disc space-y-1 pl-5 text-slate-700">
+                              {company.roles.map((role) => (
+                                <li key={`cv-result-role-${company.name}-${role}`}>{displayValue(role)}</li>
+                              ))}
+                              {company.tasks.map((task) => (
+                                <li key={`cv-result-task-${company.name}-${task}`}>{displayValue(task)}</li>
+                              ))}
+                              {company.achievements.map((achievement) => (
+                                <li key={`cv-result-achievement-${company.name}-${achievement}`}>{displayValue(achievement)}</li>
+                              ))}
+                            </ul>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                    <div className="space-y-3">
+                      <h3 className="text-lg font-semibold text-slate-900">AI提案：活かせる経験</h3>
+                      <ul className="list-disc space-y-2 pl-5 text-slate-700">
+                        {cvResult.leverage.map((item) => (
+                          <li key={`cv-result-leverage-${item.title}`}>
+                            <span className="font-semibold">{displayValue(item.title)}：</span>
+                            <span className="ml-1">{displayValue(item.example)}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                    <div className="space-y-3">
+                      <h3 className="text-lg font-semibold text-slate-900">AI生成 自己PR</h3>
+                      <p className="whitespace-pre-line text-sm leading-relaxed text-slate-700">{displayValue(cvResult.selfPR)}</p>
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+            ) : (
+              <p className="text-sm text-slate-500">職務経歴書の情報がまだ入力されていません。</p>
+            )}
+          </section>
+        </div>
       </div>
+      <style jsx global>{`
+        @page {
+          size: A4 portrait;
+          margin: 20mm;
+        }
+
+        @media print {
+          body {
+            background: #ffffff !important;
+          }
+
+          .print-container {
+            box-shadow: none !important;
+            margin: 0 auto !important;
+            width: auto !important;
+            background: #ffffff !important;
+          }
+        }
+      `}</style>
     </div>
   );
 }

--- a/src/app/preview/page.tsx
+++ b/src/app/preview/page.tsx
@@ -31,7 +31,7 @@ export default function PreviewPage() {
   const printContentRef = useRef<HTMLDivElement>(null);
 
   const triggerPrint = useReactToPrint({
-    content: () => printContentRef.current,
+    contentRef: printContentRef,
     documentTitle: profile.name ? `${profile.name}-resume` : "resume-preview",
   });
 

--- a/src/components/ui/PrimaryButton.test.tsx
+++ b/src/components/ui/PrimaryButton.test.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import PrimaryButton from "./PrimaryButton";
+
+describe("PrimaryButton", () => {
+  it("renders provided children", () => {
+    const html = renderToStaticMarkup(<PrimaryButton>確認</PrimaryButton>);
+
+    expect(html).toContain(">確認<");
+  });
+
+  it("sets disabled when loading", () => {
+    const html = renderToStaticMarkup(<PrimaryButton loading>処理</PrimaryButton>);
+
+    expect(html).toContain("disabled");
+    expect(html).toContain("aria-busy=\"true\"");
+    expect(html).toContain("処理中...");
+  });
+});

--- a/src/components/ui/PrimaryButton.tsx
+++ b/src/components/ui/PrimaryButton.tsx
@@ -1,0 +1,32 @@
+import React, { ButtonHTMLAttributes, ForwardedRef, forwardRef } from "react";
+
+export type PrimaryButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  loading?: boolean;
+};
+
+const baseClasses = "bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:bg-blue-300";
+
+const PrimaryButton = forwardRef(function PrimaryButton(
+  { children, className = "", loading = false, disabled, type = "button", ...props }: PrimaryButtonProps,
+  ref: ForwardedRef<HTMLButtonElement>,
+) {
+  const mergedClassName = className ? `${baseClasses} ${className}` : baseClasses;
+  const isDisabled = disabled || loading;
+
+  return (
+    <button
+      {...props}
+      ref={ref}
+      type={type}
+      className={mergedClassName}
+      disabled={isDisabled}
+      aria-busy={loading ? "true" : undefined}
+    >
+      {loading ? "処理中..." : children}
+    </button>
+  );
+});
+
+PrimaryButton.displayName = "PrimaryButton";
+
+export default PrimaryButton;


### PR DESCRIPTION
目的／影響範囲／触るファイル:
- 目的: /preview ページをA4想定のレイアウトに整形し印刷・PDF対応を提供
- 影響範囲: プレビュー画面のUIと操作導線、共通ボタンUI、新規テスト
- 触るファイル: src/app/preview/page.tsx, src/components/ui/PrimaryButton.tsx, src/components/ui/PrimaryButton.test.tsx

目的:
- プレビュー画面を整形し、印刷・PDF保存に対応

実装内容:
- プレビュー画面をA4幅・白背景・区切り付きに再構成し、zustandの各種情報を「未入力」フォールバック付きで表示
- react-to-printを利用して印刷／PDFダイアログを起動するボタン群と戻るボタンを配置し、印刷専用スタイルをStyle JSXで適用
- PrimaryButtonコンポーネントを src/components/ui/ に追加（目的: ボタンスタイル統一、理由: プレビュー画面の操作ボタン共通化、配置: src/components/ui/PrimaryButton.tsx）およびユニットテストを作成

動作確認手順:
- pnpm lint
- pnpm test
- pnpm build（Google Fontsの取得失敗によりローカル無ネット環境でエラー。既存仕様であり、オンライン環境では成功見込み）

既知の未対応:
- デザイン細部調整（色テーマ、フォント選定）、高度なPDFレイアウト（後続フェーズ対応）

------
https://chatgpt.com/codex/tasks/task_e_68db7b63c36883299b139d6230aefa9f