### PR TITLE
feat(P8): autosave and zod-based validation for resume/career forms

### DIFF
--- a/src/components/DraftRestoreBanner.tsx
+++ b/src/components/DraftRestoreBanner.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useState } from "react";
+
+type DraftState<T> = {
+  data?: T;
+  ts?: number;
+};
+
+type Props<T> = {
+  draft?: DraftState<T>;
+  onRestore: (data: T) => void;
+  onDiscard: () => void;
+};
+
+export function DraftRestoreBanner<T>({ draft, onRestore, onDiscard }: Props<T>) {
+  const [closed, setClosed] = useState(false);
+  if (!draft?.data || closed) return null;
+
+  const date = draft.ts ? new Date(draft.ts).toLocaleString() : "";
+
+  const handleRestore = () => {
+    onRestore(draft.data as T);
+    setClosed(true);
+  };
+
+  const handleDiscard = () => {
+    onDiscard();
+    setClosed(true);
+  };
+
+  return (
+    <div className="mb-3 flex items-center gap-3 rounded border bg-yellow-50 p-3 text-sm" role="status" aria-live="polite">
+      <span>前回の入力内容（{date} 保存）を復元しますか？</span>
+      <div className="ml-auto flex gap-2">
+        <button
+          type="button"
+          className="rounded border px-2 py-1"
+          onClick={handleRestore}
+          aria-label="前回の入力内容を復元する"
+        >
+          復元
+        </button>
+        <button
+          type="button"
+          className="rounded border px-2 py-1"
+          onClick={handleDiscard}
+          aria-label="保存済みの下書きを破棄する"
+        >
+          破棄
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useAutosave.ts
+++ b/src/hooks/useAutosave.ts
@@ -1,0 +1,65 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+type Options<T> = {
+  key: string;
+  data: T;
+  delay?: number;
+  enabled?: boolean;
+};
+
+type DraftPayload<T> = {
+  v: number;
+  t: number;
+  data: T;
+};
+
+export function useAutosave<T>({ key, data, delay = 800, enabled = true }: Options<T>) {
+  const timer = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return undefined;
+
+    if (timer.current !== null) {
+      window.clearTimeout(timer.current);
+    }
+
+    timer.current = window.setTimeout(() => {
+      try {
+        const payload: DraftPayload<T> = { v: 1, t: Date.now(), data };
+        localStorage.setItem(key, JSON.stringify(payload));
+      } catch {
+        // noop
+      }
+    }, delay);
+
+    return () => {
+      if (timer.current !== null) {
+        window.clearTimeout(timer.current);
+      }
+    };
+  }, [data, delay, enabled, key]);
+}
+
+export function loadDraft<T>(key: string): { data?: T; ts?: number } {
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as Partial<DraftPayload<T>> | null;
+    if (!parsed || typeof parsed !== "object") return {};
+    const data = "data" in parsed ? (parsed.data as T | undefined) : undefined;
+    const ts = typeof parsed?.t === "number" ? parsed.t : undefined;
+    return { data, ts };
+  } catch {
+    return {};
+  }
+}
+
+export function clearDraft(key: string) {
+  try {
+    localStorage.removeItem(key);
+  } catch {
+    // noop
+  }
+}

--- a/src/lib/validate/zod.test.ts
+++ b/src/lib/validate/zod.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { zResumeForm, zResumeProfile } from "./zod";
+
+describe("zResumeProfile", () => {
+  it("rejects an invalid email address", () => {
+    const result = zResumeProfile.safeParse({
+      name: "山田 太郎",
+      birthday: "1990-01-01",
+      address: "東京都新宿区",
+      phone: "080-0000-0000",
+      email: "invalid-email",
+      photoUrl: "",
+    });
+
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("zResumeForm", () => {
+  it("accepts a fully populated resume", () => {
+    const result = zResumeForm.safeParse({
+      profile: {
+        name: "山田 太郎",
+        birthday: "1990-01-01",
+        address: "東京都新宿区",
+        phone: "080-0000-0000",
+        email: "taro@example.com",
+        photoUrl: "https://example.com/photo.jpg",
+      },
+      education: [
+        {
+          start: "2008-04",
+          end: "2012-03",
+          title: "AI大学 工学部",
+          detail: "情報工学科",
+          status: "卒業",
+        },
+      ],
+      work: [
+        {
+          start: "2012-04",
+          end: "2020-03",
+          title: "株式会社テック 研究開発部",
+          detail: "ソフトウェアエンジニア",
+          status: "退社",
+        },
+      ],
+      licenses: [
+        {
+          name: "応用情報技術者",
+          acquiredOn: "2015-06-01",
+        },
+      ],
+      pr: {
+        answers: ["A", "B", "C", "D", "E"],
+        generated: "自己PR文",
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/lib/validate/zod.ts
+++ b/src/lib/validate/zod.ts
@@ -1,39 +1,56 @@
 import { z } from "zod";
 
-export const zYyyyMm = z.string().regex(/^\d{4}-(0[1-9]|1[0-2])$/);
-export const zYyyyMmDd = z.string().regex(/^\d{4}-\d{2}-\d{2}$/);
-
+/** 履歴書 基本情報 */
 export const zResumeProfile = z.object({
-  name: z.string().min(1).max(64),
-  kana: z.string().max(64).optional(),
-  birth: zYyyyMmDd,
-  address: z.string().min(1),
-  email: z.string().email().optional(),
-  phone: z.string().max(32).optional(),
-  photoBase64: z.string().max(2_400_000).optional()
+  name: z.string().min(1, "氏名は必須です").max(80),
+  birthday: z.string().min(1, "生年月日は必須です"),
+  address: z.string().min(1, "住所は必須です").max(200),
+  phone: z.string().min(1, "電話番号は必須です").max(40),
+  email: z.string().email("メール形式が不正です"),
+  photoUrl: z.string().url().optional().or(z.literal("").transform(() => undefined)),
 });
 
-export const zResumeHistory = z.object({
-  yyyymm: zYyyyMm,
-  org: z.string().min(1),
-  detail: z.string().optional(),
-  kind: z.enum(["蜈･蟄ｦ","蜊呈･ｭ","荳ｭ騾秘蟄ｦ","蜈･遉ｾ","騾遉ｾ","髢区･ｭ","髢画･ｭ"])
+/** 学歴・職歴エントリ */
+export const zEduWorkEntry = z.object({
+  start: z.string().min(1, "開始年月は必須です"),
+  end: z.string().optional(),
+  title: z.string().min(1, "内容は必須です").max(120),
+  detail: z.string().max(500).optional(),
+  status: z.enum(["入学", "卒業", "中途退学", "入社", "退社", "開業", "閉業"]).optional(),
 });
 
-export const zJobExperience = z.object({
-  company: z.string().min(1),
-  term: z.object({ from: zYyyyMmDd, to: zYyyyMmDd.optional() }),
-  role: z.string().optional(),
-  tasks: z.array(z.string()).optional(),
-  achievements: z.array(z.string()).optional()
+/** 免許・資格 */
+export const zLicenseEntry = z.object({
+  name: z.string().min(1, "資格名は必須です").max(120),
+  acquiredOn: z.string().optional(),
 });
 
-export const zResumePRReq = z.object({
-  answers: z.array(z.string()).length(5),
+/** 自己PR（5回答＋生成文） */
+export const zResumePR = z.object({
+  answers: z.array(z.string().max(400)).length(5, "5つの回答が必要です"),
+  generated: z.string().optional(),
+});
+
+export const zResumePRAnswers = zResumePR.shape.answers;
+
+/** 履歴書フォーム全体 */
+export const zResumeForm = z.object({
   profile: zResumeProfile,
-  history: z.array(zResumeHistory)
+  education: z.array(zEduWorkEntry),
+  work: z.array(zEduWorkEntry),
+  licenses: z.array(zLicenseEntry),
+  pr: zResumePR,
 });
 
-export const zResumePRAnswers = z.object({
-  answers: z.array(z.string()).length(5)
+/** 職務経歴（会社単位） */
+export const zCareerCompany = z.object({
+  company: z.string().min(1, "会社名は必須です"),
+  period: z.string().min(1, "期間は必須です"),
+  role: z.string().min(1, "役割は必須です"),
+  achievements: z.array(z.string().max(400)).min(1, "実績を1つ以上入力してください"),
+});
+
+export const zCareerForm = z.object({
+  profile: zResumeProfile.partial(),
+  companies: z.array(zCareerCompany),
 });


### PR DESCRIPTION
## Purpose / Impact
- Implement the P8 autosave and validation experience upgrades so users can safely resume resume/career editing and avoid invalid previews.

## Changes
- Introduced shared Zod schemas plus regression tests for resume/career payloads and exported PR answer schema used by AI routes.
- Added a reusable autosave hook with localStorage helpers and a draft-restore banner component.
- Wired autosave/restore and inline validation feedback into the resume profile form.
- Guarded preview navigation from the resume PR screen by validating stored form data and surfacing actionable warnings.

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build` *(fails: Next.js cannot download Google Fonts in the offline environment)*

## Screenshots
- Unable to capture in the current headless environment.


------
https://chatgpt.com/codex/tasks/task_e_68db914e4df483298f0c4b7716f5749b