### PR TITLE
Add Playwright E2E regression tests with SSR mocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,11 @@
     "build": "next build --turbopack",
     "start": "next start",
     "lint": "eslint",
-    "test": "vitest"
+    "test": "vitest",
+    "test:e2e": "cross-env E2E_MOCK=1 PLAYWRIGHT_HTML_REPORT=html playwright test",
+    "test:e2e:ui": "cross-env E2E_MOCK=1 playwright test --ui",
+    "test:e2e:headed": "cross-env E2E_MOCK=1 playwright test --headed",
+    "test:e2e:update": "cross-env E2E_MOCK=1 playwright test -u"
   },
   "dependencies": {
     "@google/generative-ai": "0.24.1",
@@ -27,6 +31,8 @@
     "@types/react": "19.1.15",
     "eslint": "^9",
     "eslint-config-next": "15.5.2",
-    "vitest": "^1.6.0"
+    "vitest": "^1.6.0",
+    "@playwright/test": "^1.47.2",
+    "cross-env": "^7.0.3"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "tests/e2e",
+  timeout: 90_000,
+  expect: { timeout: 10_000 },
+  fullyParallel: true,
+  reporter: [["list"], ["html", { outputFolder: "html" }]],
+  use: {
+    baseURL: process.env.BASE_URL || "http://localhost:3000",
+    trace: "retain-on-failure",
+    video: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+  webServer: {
+    command: "pnpm dev",
+    port: 3000,
+    reuseExistingServer: !process.env.CI,
+    env: {
+      NEXT_PUBLIC_APP_URL: "http://localhost:3000",
+      E2E_MOCK: "1",
+    },
+  },
+  projects: [
+    { name: "chromium", use: { ...devices["Desktop Chrome"] } },
+  ],
+});

--- a/src/app/api/share/[token]/route.ts
+++ b/src/app/api/share/[token]/route.ts
@@ -68,6 +68,71 @@ export async function GET(
     return NextResponse.json({ message: "Token missing" }, { status: 400 });
   }
 
+  if (process.env.E2E_MOCK === "1" && token === "mocktoken") {
+    return NextResponse.json(
+      {
+        resume: {
+          profile: {
+            name: "山田太郎",
+            nameKana: "ヤマダタロウ",
+            birth: "1990-01-01",
+            address: "東京都",
+            phone: "090-0000-0000",
+            email: "taro@example.com",
+            avatarUrl: "",
+          },
+          education: [
+            {
+              school: "AI大学 情報工学部",
+              degree: "卒業",
+              start: "2008-04",
+              end: "2012-03",
+              status: "卒業",
+            },
+          ],
+          employment: [
+            {
+              company: "株式会社サンプル",
+              role: "開発エンジニア",
+              start: "2012-04",
+              end: "2020-03",
+              status: "退社",
+            },
+          ],
+          licenses: [
+            {
+              name: "基本情報技術者",
+              obtainedOn: "2011-11-01",
+            },
+          ],
+          prText: "モック共有の自己PRです。",
+        },
+        career: {
+          cv: {
+            jobProfile: {
+              name: "山田太郎",
+              title: "リードエンジニア",
+              summary: "AIプロダクト開発に従事",
+            },
+            experiences: [
+              {
+                company: "株式会社サンプル",
+                role: "プロジェクトマネージャー",
+                period: "2018-04〜2020-03",
+                achievements: [
+                  "AIレジュメ自動化システムを導入し、作業時間を50%削減",
+                ],
+              },
+            ],
+          },
+          cvText: "主要プロジェクトでAI活用を推進。",
+        },
+        templateId: "standard",
+      },
+      { status: 200 },
+    );
+  }
+
   try {
     const kvData = await fetchShareData(token);
 

--- a/tests/e2e/flow.spec.ts
+++ b/tests/e2e/flow.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "@playwright/test";
+import { mockAIAndShare } from "./utils/mock";
+
+declare global {
+  interface Window {
+    __printed__?: boolean;
+  }
+}
+
+test.describe("主要フロー: 入力→AI生成→プレビュー/印刷→共有", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAIAndShare(page);
+  });
+
+  test("トップが表示され、ナビがある", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByRole("heading", { name: /AI-ROBI/ })).toBeVisible();
+    await expect(page.getByRole("link", { name: /履歴書|Resume/i })).toBeVisible();
+  });
+
+  test("プロフィール入力→自己PR AI生成→プレビューで反映", async ({ page }) => {
+    await page.goto("/resume/profile");
+
+    await page.getByLabel(/氏名|Full Name/i).fill("山田太郎");
+    await page.getByLabel(/生年月日|Date of Birth/i).fill("1990-01-01");
+    await page.getByLabel(/住所|Address/i).fill("東京都");
+    await page.getByLabel(/電話|Phone/i).fill("090-0000-0000");
+    await page.getByLabel(/メール|Email/i).fill("taro@example.com");
+    await page.getByRole("button", { name: /保存/ }).click();
+
+    await page.goto("/resume/pr");
+    const generateButton = page.getByRole("button", { name: /AI.*自己PR|AI.*PR|AI生成/ });
+    await generateButton.click();
+    const generatedTextarea = page.getByLabel("生成結果の編集内容");
+    await expect(generatedTextarea).toContainText(/モック自己PR/);
+
+    await page.getByRole("button", { name: /この内容を反映/ }).click();
+    await page.goto("/preview");
+
+    await expect(page.getByRole("button", { name: /印刷|Print/ })).toBeVisible();
+    await expect(page.getByText(/モック自己PR/)).toBeVisible();
+  });
+
+  test("印刷ボタンはwindow.printを呼ぶ", async ({ page }) => {
+    await page.addInitScript(() => {
+      const scopedWindow = window as Window & { __printed__?: boolean };
+      scopedWindow.__printed__ = false;
+      const originalPrint = scopedWindow.print.bind(scopedWindow);
+      scopedWindow.print = () => {
+        scopedWindow.__printed__ = true;
+        originalPrint();
+      };
+    });
+
+    await page.goto("/preview");
+    await page.getByRole("button", { name: /印刷|Print/ }).click();
+    const printed = await page.evaluate(() => window.__printed__ === true);
+    expect(printed).toBe(true);
+  });
+
+  test("共有リンクの発行→共有ページで閲覧できる", async ({ page }) => {
+    await page.goto("/preview");
+    await page.getByRole("button", { name: /共有/ }).click();
+
+    await page.goto("/share/mocktoken");
+    await expect(page.getByText(/山田太郎/)).toBeVisible();
+    await expect(page.getByText(/モック共有の自己PR/)).toBeVisible();
+  });
+});

--- a/tests/e2e/utils/mock.ts
+++ b/tests/e2e/utils/mock.ts
@@ -1,0 +1,103 @@
+import { Page } from "@playwright/test";
+
+export async function mockAIAndShare(page: Page) {
+  await page.route("**/api/ai/generate-resume", async (route) => {
+    const json = {
+      result: "これはE2Eのモック自己PRテキストです（具体例・数値を含む）。",
+    };
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(json),
+    });
+  });
+
+  await page.route("**/api/ai/generate-career", async (route) => {
+    const json = {
+      result: "これはE2Eのモック職務経歴テキストです（役割・KPIを含む）。",
+    };
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(json),
+    });
+  });
+
+  await page.route("**/api/share", async (route) => {
+    const json = {
+      url: `${process.env.BASE_URL || "http://localhost:3000"}/share/mocktoken`,
+    };
+    await route.fulfill({
+      status: 201,
+      contentType: "application/json",
+      body: JSON.stringify(json),
+    });
+  });
+
+  await page.route("**/api/share/*", async (route) => {
+    const json = {
+      resume: {
+        profile: {
+          name: "山田太郎",
+          nameKana: "ヤマダタロウ",
+          birth: "1990-01-01",
+          address: "東京都",
+          phone: "090-0000-0000",
+          email: "taro@example.com",
+          avatarUrl: "",
+        },
+        education: [
+          {
+            school: "AI大学 情報工学部",
+            degree: "卒業",
+            start: "2008-04",
+            end: "2012-03",
+            status: "卒業",
+          },
+        ],
+        employment: [
+          {
+            company: "株式会社サンプル",
+            role: "開発エンジニア",
+            start: "2012-04",
+            end: "2020-03",
+            status: "退社",
+          },
+        ],
+        licenses: [
+          {
+            name: "基本情報技術者",
+            obtainedOn: "2011-11-01",
+          },
+        ],
+        prText: "モック共有の自己PRです。",
+      },
+      career: {
+        cv: {
+          jobProfile: {
+            name: "山田太郎",
+            title: "リードエンジニア",
+            summary: "AIプロダクト開発に従事",
+          },
+          experiences: [
+            {
+              company: "株式会社サンプル",
+              role: "プロジェクトマネージャー",
+              period: "2018-04〜2020-03",
+              achievements: [
+                "AIレジュメ自動化システムを導入し、作業時間を50%削減",
+              ],
+            },
+          ],
+        },
+        cvText: "主要プロジェクトでAI活用を推進。",
+      },
+      templateId: "standard",
+    } as const;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(json),
+    });
+  });
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    exclude: ["**/node_modules/**", "**/dist/**", "**/tests/e2e/**"],
+  },
+});


### PR DESCRIPTION
目的: Playwright を用いた主要フローのE2E回帰テストを追加し、モックを使って外部依存なく動作確認できるようにする。
影響範囲: テスト基盤 (Playwright/Vitest)・共有APIのSSR分岐・npmスクリプト。
触るファイル: package.json / playwright.config.ts / tests/e2e/** / vitest.config.ts / src/app/api/share/[token]/route.ts

変更点
- Playwright 設定と主要フロー（入力→AI生成→プレビュー→共有）のE2Eテスト、共通モックを追加。
- pnpm スクリプトに E2E テストコマンドを追加し、Vitest から E2E ディレクトリを除外。
- E2E_MOCK=1 時に `/api/share/[token]` が mocktoken を返却する SSR ガードを実装。

新規ファイル（目的・理由・配置）
- playwright.config.ts: Playwright の実行設定。ルート直下に配置して `pnpm test:e2e` から参照。
- tests/e2e/utils/mock.ts: APIレスポンスのネットワークモックを共通化するヘルパー。E2E ディレクトリ内に配置。
- tests/e2e/flow.spec.ts: 主要ユーザーフローのE2Eテスト本体。E2E ディレクトリ内に配置。
- vitest.config.ts: Vitest 実行時に E2E テストを除外するための設定。ルート直下に配置。

テスト結果
- `pnpm build`
- `pnpm test`
- `pnpm lint`
- `pnpm test:e2e` は Playwright パッケージを取得できない（403）ため未実施。

------
https://chatgpt.com/codex/tasks/task_e_68dd30d4dbc88329822005fde8773ba0