### PR TITLE
Fix layout styling fallback to avoid plain text rendering

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import "./globals.css";
+import "@/styles/globals.css";
 import "@/styles/print.css";
 import "@/styles/a11y.css";
 import Link from "next/link";
@@ -20,11 +21,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           >
             コンテンツへスキップ
           </a>
-          <div className="mx-auto flex w-full max-w-4xl justify-end px-4 pt-2" data-hide-on-print>
+          <div className="container mx-auto flex w-full max-w-4xl justify-end px-4 pt-2" data-hide-on-print>
             <LangSwitcher />
           </div>
           <header className="border-b bg-white/95 shadow-sm backdrop-blur" data-hide-on-print id="top" role="banner">
-            <div className="mx-auto flex max-w-4xl flex-col gap-4 px-4 py-4 md:flex-row md:items-center md:justify-between">
+            <div className="container mx-auto flex max-w-4xl flex-col gap-4 px-4 py-4 md:flex-row md:items-center md:justify-between">
               <Link
                 href="/"
                 className="inline-flex items-center text-lg font-semibold tracking-tight text-slate-900"
@@ -37,7 +38,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <main
             id="main"
             role="main"
-            className="mx-auto min-h-[calc(100vh-5rem)] w-full max-w-4xl px-4 py-6 md:py-10"
+            className="container mx-auto min-h-[calc(100vh-5rem)] w-full max-w-4xl px-4 py-6 md:py-10"
           >
             {children}
           </main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,38 +8,38 @@ export default function Page() {
   const { t } = useI18n();
   return (
     <div className="space-y-6">
-      <section className="rounded-xl bg-white p-8 shadow-sm">
-        <h1 className="text-3xl font-semibold text-slate-900">{t("app.title")}</h1>
+      <section className="card rounded-xl bg-white p-8 shadow-sm">
+        <h1 className="h1 text-3xl font-semibold text-slate-900">{t("app.title")}</h1>
         <p className="mt-2 text-sm text-slate-600">
           履歴書・職務経歴書の入力フォームに情報を登録し、AI補助でドキュメントを整えましょう。
         </p>
         <div className="mt-6 flex flex-col gap-3 sm:flex-row">
           <Link
-            className="inline-flex items-center justify-center rounded-md bg-slate-900 px-6 py-3 text-sm font-medium text-white shadow-sm transition hover:bg-slate-800"
+            className="btn primary inline-flex items-center justify-center rounded-md bg-slate-900 px-6 py-3 text-sm font-medium text-white shadow-sm transition hover:bg-slate-800"
             href="/resume/profile"
           >
             履歴書を作成
           </Link>
           <Link
-            className="inline-flex items-center justify-center rounded-md border border-slate-300 px-6 py-3 text-sm font-medium text-slate-800 transition hover:bg-slate-100"
+            className="btn inline-flex items-center justify-center rounded-md border border-slate-300 px-6 py-3 text-sm font-medium text-slate-800 transition hover:bg-slate-100"
             href="/cv"
           >
             職務経歴書を作成
           </Link>
           <Link
-            className="inline-flex items-center justify-center rounded-md border border-slate-300 px-6 py-3 text-sm font-medium text-slate-800 transition hover:bg-slate-100"
+            className="btn inline-flex items-center justify-center rounded-md border border-slate-300 px-6 py-3 text-sm font-medium text-slate-800 transition hover:bg-slate-100"
             href="/preview"
           >
             プレビュー
           </Link>
         </div>
       </section>
-      <section className="rounded-xl bg-white p-8 shadow-sm">
-        <h2 className="text-xl font-semibold text-slate-900">{t("home.flow.title")}</h2>
+      <section className="card rounded-xl bg-white p-8 shadow-sm">
+        <h2 className="h2 text-xl font-semibold text-slate-900">{t("home.flow.title")}</h2>
         <ol className="mt-4 list-decimal space-y-2 pl-5 text-sm text-slate-700">
-          <li>{t("home.flow.1")}</li>
-          <li>{t("home.flow.2")}</li>
-          <li>{t("home.flow.3")}</li>
+          <li className="mt-2">{t("home.flow.1")}</li>
+          <li className="mt-2">{t("home.flow.2")}</li>
+          <li className="mt-2">{t("home.flow.3")}</li>
         </ol>
       </section>
     </div>

--- a/src/app/preview/page.test.ts
+++ b/src/app/preview/page.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import type { ResumeData } from "@/templates/types";
+import { hasResumeDataContent } from "./page";
+
+const createResumeData = (overrides: Partial<ResumeData>): ResumeData => ({
+  profile: {
+    name: "",
+    address: "",
+    phone: "",
+    email: "",
+    ...overrides.profile,
+  },
+  education: overrides.education ?? [],
+  work: overrides.work ?? [],
+  licenses: overrides.licenses ?? [],
+  pr: overrides.pr,
+  career: overrides.career,
+});
+
+describe("hasResumeDataContent", () => {
+  it("returns false when no sections contain content", () => {
+    const data = createResumeData({});
+    expect(hasResumeDataContent(data)).toBe(false);
+  });
+
+  it("returns true when profile contains visible text", () => {
+    const data = createResumeData({ profile: { name: "山田太郎" } });
+    expect(hasResumeDataContent(data)).toBe(true);
+  });
+
+  it("returns true when generated career exists", () => {
+    const data = createResumeData({ career: { generatedCareer: "経歴のサマリー" } });
+    expect(hasResumeDataContent(data)).toBe(true);
+  });
+});

--- a/src/app/preview/page.tsx
+++ b/src/app/preview/page.tsx
@@ -175,16 +175,16 @@ export default function PreviewPage() {
 
   return (
     <div className="min-h-screen bg-slate-100 py-8 print:bg-white print:py-0">
-      <div className="mx-auto w-full max-w-[820px] px-4 print:w-auto print:max-w-none print:px-0">
-        <div className="mb-4 flex flex-col gap-4 print:hidden" data-hide-on-print>
-          <div className="flex flex-wrap items-center justify-end gap-3">
-            <div className="flex items-center gap-2">
+      <div className="container mx-auto w-full max-w-[820px] px-4 print:w-auto print:max-w-none print:px-0">
+        <div className="card mb-4 flex flex-col gap-4 print:hidden" data-hide-on-print>
+          <div className="space-b row flex flex-wrap items-center gap-3">
+            <div className="row flex items-center gap-2">
               <label htmlFor="template-select" className="text-sm font-medium text-slate-700">
                 {t("preview.template")}
               </label>
               <select
                 id="template-select"
-                className="rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500"
+                className="border p-2 text-sm text-slate-800 rounded border-slate-300 bg-white px-3 py-2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500"
                 value={templateId}
                 onChange={(event) => setTemplate(event.target.value as TemplateId)}
               >
@@ -195,30 +195,37 @@ export default function PreviewPage() {
                 ))}
               </select>
             </div>
-            <PrimaryButton onClick={handleShare} loading={isSharing} aria-label="共有リンクを発行する">
-              {t("share.create")}
-            </PrimaryButton>
-            <PrimaryButton onClick={handlePrint} aria-label="印刷プレビューを開く">
-              {t("preview.print")}
-            </PrimaryButton>
-            <PrimaryButton onClick={handlePdfDownload} aria-label="PDFとして保存する">
-              PDFダウンロード
-            </PrimaryButton>
-            <PrimaryButton onClick={handleBack} aria-label="入力画面に戻る">
-              戻る
-            </PrimaryButton>
+            <div className="row flex flex-wrap gap-2">
+              <PrimaryButton
+                className="btn primary"
+                onClick={handleShare}
+                loading={isSharing}
+                aria-label="共有リンクを発行する"
+              >
+                {t("share.create")}
+              </PrimaryButton>
+              <PrimaryButton className="btn" onClick={handlePrint} aria-label="印刷プレビューを開く">
+                {t("preview.print")}
+              </PrimaryButton>
+              <PrimaryButton className="btn" onClick={handlePdfDownload} aria-label="PDFとして保存する">
+                PDFダウンロード
+              </PrimaryButton>
+              <PrimaryButton className="btn" onClick={handleBack} aria-label="入力画面に戻る">
+                戻る
+              </PrimaryButton>
+            </div>
           </div>
 
           {shareUrl ? (
-            <div className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm" role="group" aria-labelledby="share-link-heading">
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="card rounded-lg border border-slate-200 bg-white p-4 shadow-sm" role="group" aria-labelledby="share-link-heading">
+              <div className="space-b flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                 <div className="flex-1 sm:pr-4">
                   <h2 id="share-link-heading" className="text-sm font-semibold text-slate-900">
                     共有用リンク（7日後に失効）
                   </h2>
                   <p className="mt-1 text-xs text-slate-500">URLを知っている相手のみが閲覧できます。編集やAI生成はできません。</p>
                 </div>
-                <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center">
+                <div className="row flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center">
                   <label className="sr-only" htmlFor="share-link-input">
                     共有用URL
                   </label>
@@ -226,10 +233,10 @@ export default function PreviewPage() {
                     id="share-link-input"
                     value={shareUrl}
                     readOnly
-                    className="w-full flex-1 rounded border border-slate-300 bg-slate-50 px-3 py-2 text-sm text-slate-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500"
+                    className="border w-full flex-1 bg-slate-50 p-2 text-sm text-slate-700 rounded border-slate-300 px-3 py-2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500"
                     aria-describedby="share-link-heading"
                   />
-                  <PrimaryButton onClick={handleCopyShareUrl} aria-label="共有URLをコピーする">
+                  <PrimaryButton className="btn" onClick={handleCopyShareUrl} aria-label="共有URLをコピーする">
                     コピー
                   </PrimaryButton>
                 </div>
@@ -271,7 +278,7 @@ const textHasValue = (value?: string | null) => {
   return value.trim().length > 0;
 };
 
-const hasResumeDataContent = (data: ResumeData) => {
+export const hasResumeDataContent = (data: ResumeData) => {
   if (textHasValue(data.profile.name) || textHasValue(data.profile.address) || textHasValue(data.profile.email)) {
     return true;
   }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,0 +1,166 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --layout-max-width: 72rem;
+  --layout-padding: 1rem;
+  --text-muted: #6b7280;
+  --border-color: #e5e7eb;
+  --background-color: #ffffff;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Noto Sans JP", "Helvetica Neue", Arial,
+    "Apple Color Emoji", "Segoe UI Emoji";
+  background: var(--background-color);
+  color: #111827;
+}
+
+main {
+  min-height: 60vh;
+}
+
+.container {
+  max-width: var(--layout-max-width);
+  margin: 0 auto;
+  padding-left: var(--layout-padding);
+  padding-right: var(--layout-padding);
+}
+
+.h1 {
+  font-size: clamp(1.75rem, 2vw + 1rem, 2.25rem);
+  line-height: 1.2;
+  font-weight: 800;
+  margin: 1.25rem 0;
+}
+
+.h2 {
+  font-size: clamp(1.25rem, 1.2vw + 1rem, 1.5rem);
+  line-height: 1.3;
+  font-weight: 700;
+  margin: 1rem 0;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.9rem;
+  border: 1px solid var(--border-color);
+  border-radius: 0.5rem;
+  background: #ffffff;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.btn:hover {
+  background: #f9fafb;
+}
+
+.btn:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}
+
+.btn.primary {
+  background: #111827;
+  color: #ffffff;
+}
+
+.muted {
+  color: var(--text-muted);
+}
+
+.card {
+  border: 1px solid var(--border-color);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  background: #ffffff;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.space-b {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.mt-2 {
+  margin-top: 0.5rem;
+}
+
+.mt-4 {
+  margin-top: 1rem;
+}
+
+.mt-6 {
+  margin-top: 1.5rem;
+}
+
+.mb-4 {
+  margin-bottom: 1rem;
+}
+
+.gap-2 {
+  gap: 0.5rem;
+}
+
+.gap-3 {
+  gap: 0.75rem;
+}
+
+.gap-4 {
+  gap: 1rem;
+}
+
+.border {
+  border: 1px solid var(--border-color);
+}
+
+.p-2 {
+  padding: 0.5rem;
+}
+
+.p-3 {
+  padding: 0.75rem;
+}
+
+.p-4 {
+  padding: 1rem;
+}
+
+.text-sm {
+  font-size: 0.875rem;
+}
+
+.text-xs {
+  font-size: 0.75rem;
+}
+
+a {
+  color: #1d4ed8;
+  text-decoration: underline;
+}
+
+select,
+button,
+input {
+  font: inherit;
+}


### PR DESCRIPTION
## 目的
- Tailwind が無効な環境でも画面がテキストのみにならないようにグローバルスタイルとナビゲーションを整備するため

## 影響範囲
- 全ページ共通レイアウト
- トップページとプレビュー画面の操作 UI

## 触るファイル
- src/styles/globals.css
- src/app/layout.tsx
- src/app/page.tsx
- src/app/preview/page.tsx
- src/app/preview/page.test.ts

## 変更点
- フォールバック用のユーティリティを含むグローバル CSS を新設し、layout で読み込むよう修正
- 共通レイアウトに container クラスを追加して余白を確保
- トップページ・プレビュー画面のマークアップにカード/ボタン等のクラスを付与し、プレーンテキスト化を防止
- プレビュー判定ロジックのユニットテストを追加

## ロールバック手順
- `git revert 6a6bdd0 f4a385a fa2dc67`

## テスト結果
- `pnpm build`
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68ddb369436083299a3141fe3a754435