### PR TITLE
feat: modernize landing and preview UI

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,7 +13,7 @@ export const runtime = "nodejs";
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ja">
-      <body className="min-h-screen bg-slate-50 text-slate-900">
+      <body className="bg-white text-slate-900">
         <I18nProvider>
           <a
             href="#main"
@@ -21,26 +21,24 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           >
             コンテンツへスキップ
           </a>
-          <div className="container mx-auto flex w-full max-w-4xl justify-end px-4 pt-2" data-hide-on-print>
-            <LangSwitcher />
-          </div>
-          <header className="border-b bg-white/95 shadow-sm backdrop-blur" data-hide-on-print id="top" role="banner">
-            <div className="container mx-auto flex max-w-4xl flex-col gap-4 px-4 py-4 md:flex-row md:items-center md:justify-between">
-              <Link
-                href="/"
-                className="inline-flex items-center text-lg font-semibold tracking-tight text-slate-900"
-              >
+          <header
+            className="app-hd"
+            data-hide-on-print
+            id="top"
+            role="banner"
+          >
+            <div className="container flex items-center justify-between gap-4 py-4">
+              <Link href="/" className="inline-flex items-center text-lg font-semibold tracking-tight text-slate-900">
                 AI-ROBI
               </Link>
-              <MainNavigation />
+              <div className="flex items-center gap-3">
+                <MainNavigation />
+                <LangSwitcher />
+              </div>
             </div>
           </header>
-          <main
-            id="main"
-            role="main"
-            className="container mx-auto min-h-[calc(100vh-5rem)] w-full max-w-4xl px-4 py-6 md:py-10"
-          >
-            {children}
+          <main id="main" role="main" className="app-shell">
+            <div className="container py-6 md:py-10">{children}</div>
           </main>
           <footer className="sr-only" role="contentinfo">
             © AI-ROBI

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,35 +8,26 @@ export default function Page() {
   const { t } = useI18n();
   return (
     <div className="space-y-6">
-      <section className="card rounded-xl bg-white p-8 shadow-sm">
-        <h1 className="h1 text-3xl font-semibold text-slate-900">{t("app.title")}</h1>
-        <p className="mt-2 text-sm text-slate-600">
+      <section className="hero">
+        <h1 className="h1">{t("app.title")}</h1>
+        <p className="lead mb-3">
           履歴書・職務経歴書の入力フォームに情報を登録し、AI補助でドキュメントを整えましょう。
         </p>
-        <div className="mt-6 flex flex-col gap-3 sm:flex-row">
-          <Link
-            className="btn primary inline-flex items-center justify-center rounded-md bg-slate-900 px-6 py-3 text-sm font-medium text-white shadow-sm transition hover:bg-slate-800"
-            href="/resume/profile"
-          >
+        <div className="row mt-3 flex-wrap">
+          <Link className="btn primary" href="/resume/profile">
             履歴書を作成
           </Link>
-          <Link
-            className="btn inline-flex items-center justify-center rounded-md border border-slate-300 px-6 py-3 text-sm font-medium text-slate-800 transition hover:bg-slate-100"
-            href="/cv"
-          >
+          <Link className="btn outline" href="/cv">
             職務経歴書を作成
           </Link>
-          <Link
-            className="btn inline-flex items-center justify-center rounded-md border border-slate-300 px-6 py-3 text-sm font-medium text-slate-800 transition hover:bg-slate-100"
-            href="/preview"
-          >
+          <Link className="btn outline" href="/preview">
             プレビュー
           </Link>
         </div>
       </section>
-      <section className="card rounded-xl bg-white p-8 shadow-sm">
-        <h2 className="h2 text-xl font-semibold text-slate-900">{t("home.flow.title")}</h2>
-        <ol className="mt-4 list-decimal space-y-2 pl-5 text-sm text-slate-700">
+      <section className="card">
+        <h2 className="h2">{t("home.flow.title")}</h2>
+        <ol className="mt-2 list-decimal space-y-2 pl-5 text-sm text-slate-700">
           <li className="mt-2">{t("home.flow.1")}</li>
           <li className="mt-2">{t("home.flow.2")}</li>
           <li className="mt-2">{t("home.flow.3")}</li>

--- a/src/app/preview/page.tsx
+++ b/src/app/preview/page.tsx
@@ -177,14 +177,14 @@ export default function PreviewPage() {
     <div className="min-h-screen bg-slate-100 py-8 print:bg-white print:py-0">
       <div className="container mx-auto w-full max-w-[820px] px-4 print:w-auto print:max-w-none print:px-0">
         <div className="card mb-4 flex flex-col gap-4 print:hidden" data-hide-on-print>
-          <div className="space-b row flex flex-wrap items-center gap-3">
-            <div className="row flex items-center gap-2">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="row flex flex-wrap items-center gap-2">
               <label htmlFor="template-select" className="text-sm font-medium text-slate-700">
                 {t("preview.template")}
               </label>
               <select
                 id="template-select"
-                className="border p-2 text-sm text-slate-800 rounded border-slate-300 bg-white px-3 py-2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500"
+                className="border rounded px-3 py-2 text-sm text-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500"
                 value={templateId}
                 onChange={(event) => setTemplate(event.target.value as TemplateId)}
               >
@@ -197,20 +197,32 @@ export default function PreviewPage() {
             </div>
             <div className="row flex flex-wrap gap-2">
               <PrimaryButton
-                className="btn primary"
+                className="btn primary !border-slate-900 !bg-slate-900 !text-white hover:!bg-slate-800"
                 onClick={handleShare}
                 loading={isSharing}
                 aria-label="共有リンクを発行する"
               >
                 {t("share.create")}
               </PrimaryButton>
-              <PrimaryButton className="btn" onClick={handlePrint} aria-label="印刷プレビューを開く">
+              <PrimaryButton
+                className="btn !bg-white !text-slate-900 hover:!bg-slate-100"
+                onClick={handlePrint}
+                aria-label="印刷プレビューを開く"
+              >
                 {t("preview.print")}
               </PrimaryButton>
-              <PrimaryButton className="btn" onClick={handlePdfDownload} aria-label="PDFとして保存する">
+              <PrimaryButton
+                className="btn !bg-white !text-slate-900 hover:!bg-slate-100"
+                onClick={handlePdfDownload}
+                aria-label="PDFとして保存する"
+              >
                 PDFダウンロード
               </PrimaryButton>
-              <PrimaryButton className="btn" onClick={handleBack} aria-label="入力画面に戻る">
+              <PrimaryButton
+                className="btn !bg-white !text-slate-900 hover:!bg-slate-100"
+                onClick={handleBack}
+                aria-label="入力画面に戻る"
+              >
                 戻る
               </PrimaryButton>
             </div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -21,10 +21,16 @@ body {
     "Apple Color Emoji", "Segoe UI Emoji";
   background: var(--background-color);
   color: #111827;
+  -webkit-font-smoothing: antialiased;
 }
 
 main {
   min-height: 60vh;
+}
+
+.app-shell {
+  background: #f9fafb;
+  min-height: 100dvh;
 }
 
 .container {
@@ -35,17 +41,24 @@ main {
 }
 
 .h1 {
-  font-size: clamp(1.75rem, 2vw + 1rem, 2.25rem);
+  font-size: clamp(1.875rem, 1.2rem + 1.2vw, 2.5rem);
   line-height: 1.2;
   font-weight: 800;
+  letter-spacing: -0.01em;
   margin: 1.25rem 0;
 }
 
 .h2 {
-  font-size: clamp(1.25rem, 1.2vw + 1rem, 1.5rem);
-  line-height: 1.3;
+  font-size: clamp(1.25rem, 1rem + 0.6vw, 1.5rem);
+  line-height: 1.35;
   font-weight: 700;
   margin: 1rem 0;
+}
+
+.lead {
+  color: #374151;
+  font-size: 1.0625rem;
+  line-height: 1.8;
 }
 
 .btn {
@@ -53,17 +66,22 @@ main {
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
-  padding: 0.5rem 0.9rem;
+  padding: 0.55rem 0.9rem;
   border: 1px solid var(--border-color);
-  border-radius: 0.5rem;
+  border-radius: 0.6rem;
   background: #ffffff;
   font-weight: 600;
   cursor: pointer;
   text-decoration: none;
+  transition: box-shadow 0.15s ease, transform 0.02s ease;
 }
 
 .btn:hover {
-  background: #f9fafb;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.04), 0 2px 12px rgba(0, 0, 0, 0.06);
+}
+
+.btn:active {
+  transform: translateY(1px);
 }
 
 .btn:focus-visible {
@@ -74,18 +92,59 @@ main {
 .btn.primary {
   background: #111827;
   color: #ffffff;
+  border-color: #111827;
+}
+
+.btn.ghost {
+  background: transparent;
+}
+
+.btn.outline {
+  background: #ffffff;
+}
+
+.btn.sm {
+  padding: 0.4rem 0.65rem;
+  font-size: 0.9rem;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.3rem 0.6rem;
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  background: #ffffff;
+  font-size: 0.875rem;
 }
 
 .muted {
   color: var(--text-muted);
 }
 
+.link {
+  color: #1f2937;
+  text-decoration: none;
+}
+
+.link:hover {
+  color: #111827;
+}
+
 .card {
   border: 1px solid var(--border-color);
-  border-radius: 0.75rem;
-  padding: 1rem;
+  border-radius: 0.9rem;
+  padding: 1.1rem;
   background: #ffffff;
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.02);
+}
+
+.hero {
+  border: 1px solid var(--border-color);
+  border-radius: 1rem;
+  padding: 1.25rem;
+  background: linear-gradient(180deg, #ffffff, #fafafa);
+  box-shadow: 0 2px 20px rgba(17, 24, 39, 0.04);
 }
 
 .row {
@@ -102,8 +161,16 @@ main {
   flex-wrap: wrap;
 }
 
+.mt-1 {
+  margin-top: 0.25rem;
+}
+
 .mt-2 {
   margin-top: 0.5rem;
+}
+
+.mt-3 {
+  margin-top: 0.75rem;
 }
 
 .mt-4 {
@@ -114,8 +181,32 @@ main {
   margin-top: 1.5rem;
 }
 
+.mb-2 {
+  margin-bottom: 0.5rem;
+}
+
+.mb-3 {
+  margin-bottom: 0.75rem;
+}
+
 .mb-4 {
   margin-bottom: 1rem;
+}
+
+.pt-2 {
+  padding-top: 0.5rem;
+}
+
+.pb-2 {
+  padding-bottom: 0.5rem;
+}
+
+.py-4 {
+  padding-block: 1rem;
+}
+
+.grid {
+  display: grid;
 }
 
 .gap-2 {
@@ -128,6 +219,22 @@ main {
 
 .gap-4 {
   gap: 1rem;
+}
+
+.w-32 {
+  width: 8rem;
+}
+
+.h-24 {
+  height: 6rem;
+}
+
+.object-cover {
+  object-fit: cover;
+}
+
+.rounded {
+  border-radius: 0.5rem;
 }
 
 .border {
@@ -156,7 +263,52 @@ main {
 
 a {
   color: #1d4ed8;
-  text-decoration: underline;
+  text-decoration: none;
+}
+
+header.app-hd {
+  position: sticky;
+  top: 0;
+  z-index: 40;
+  backdrop-filter: saturate(180%) blur(6px);
+  background: rgba(255, 255, 255, 0.8);
+  border-bottom: 1px solid var(--border-color);
+}
+
+nav.primary a {
+  padding: 0.4rem 0.6rem;
+  border-radius: 0.5rem;
+}
+
+nav.primary a:hover {
+  background: #f3f4f6;
+}
+
+nav[aria-label="主要ナビゲーション"] {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+nav[aria-label="主要ナビゲーション"] a {
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid var(--border-color);
+  background: #ffffff;
+  color: #374151;
+  text-decoration: none !important;
+  transition: background 0.15s ease, box-shadow 0.15s ease;
+}
+
+nav[aria-label="主要ナビゲーション"] a:hover {
+  background: #f3f4f6;
+}
+
+nav[aria-label="主要ナビゲーション"] a[aria-current="page"] {
+  background: #111827;
+  color: #ffffff;
+  border-color: #111827;
+  box-shadow: 0 2px 10px rgba(17, 24, 39, 0.08);
 }
 
 select,


### PR DESCRIPTION
目的 / 影響範囲 / 触るファイル
- 目的: 既存機能を保ちつつレイアウトと主要画面のUIをモダンなトーンに刷新し、ナビゲーションとCTAの一貫性を高める。
- 影響範囲: 全ページ共通シェル、トップページ、プレビュー画面の操作部、および共通スタイル定義。
- 触るファイル: src/styles/globals.css, src/app/layout.tsx, src/app/page.tsx, src/app/preview/page.tsx

変更点
- デザイントークンとUIユーティリティを拡充し、ボタン・カード・チップなどの見た目を統一。
- 共通レイアウトのヘッダーを半透明背景＋チップ風ナビに変更し、本文をセンタリングされたシェルに配置。
- トップページをヒーローセクション＋リード文と統一CTAで再構成。
- プレビュー画面の操作列をカード化し、ボタン類とセレクターの余白・配色を統一。

影響範囲
- ヘッダー／ナビゲーションのスタイルが全ページで更新されます。
- トップ画面およびプレビュー画面の余白・フォント・ボタン配色が変わりますが、機能的な挙動は維持しています。

ロールバック手順
- `git revert b45073d c9aff20 db1dd4c e9e7a5a`

テスト結果
- `pnpm build`
- `pnpm test -- --run`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68ddbb1a619c832996b18f0dcd7f92d0